### PR TITLE
Add SVG driver

### DIFF
--- a/src/DmplBuilder.php
+++ b/src/DmplBuilder.php
@@ -81,7 +81,7 @@ class DmplBuilder implements PlotBuilder
      *
      * @return string
      */
-    public function compileDmpl(): string
+    public function compile(): string
     {
         $init = sprintf(';: EC%s,U H L0,A100,100,R,', $this->measuringUnit);
 

--- a/src/DmplBuilder.php
+++ b/src/DmplBuilder.php
@@ -49,12 +49,8 @@ class DmplBuilder implements PlotBuilder
 
     /**
      * Adds a new plot of x and y to machine instructions.
-     *
-     * @param int $x
-     * @param int $y
-     * @return $this
      */
-    public function plot(int $x, int $y)
+    public function plot(int $x, int $y): PlotBuilder
     {
         array_map([$this, 'pushCommand'], $this->flipAxes ? [$y, $x] : [$x, $y]);
 
@@ -63,11 +59,8 @@ class DmplBuilder implements PlotBuilder
 
     /**
      * Changes the pen of the plotter.
-     *
-     * @param int $pen
-     * @return $this
      */
-    public function changePen(int $pen)
+    public function changePen(int $pen): PlotBuilder
     {
         if (! in_array($pen, range(0, 6))) {
             throw new \InvalidArgumentException(sprintf('[%d] is not a valid Pen.', $pen));
@@ -78,8 +71,6 @@ class DmplBuilder implements PlotBuilder
 
     /**
      * Compiles a string in DMPL format with machine instructions.
-     *
-     * @return string
      */
     public function compile(): string
     {
@@ -92,11 +83,8 @@ class DmplBuilder implements PlotBuilder
 
     /**
      * Pushes a command to the instructions.
-     *
-     * @param string $command
-     * @return $this
      */
-    public function pushCommand(string $command)
+    public function pushCommand(string $command): PlotBuilder
     {
         $this->instructions[] = $command;
 
@@ -105,51 +93,40 @@ class DmplBuilder implements PlotBuilder
 
     /**
      * Lifts the pen up.
-     *
-     * @return $this
      */
-    public function penUp()
+    public function penUp(): PlotBuilder
     {
         return $this->pushCommand('U');
     }
 
     /**
      * Pushes the pen down on paper.
-     *
-     * @return $this
      */
-    public function penDown()
+    public function penDown(): PlotBuilder
     {
         return $this->pushCommand('D');
     }
 
     /**
      * Changes the plotter pen to use flexcut.
-     *
-     * @return $this
      */
-    public function flexCut()
+    public function flexCut(): PlotBuilder
     {
         return $this->changePen(self::FLEXCUT_PEN);
     }
 
     /**
      * Change to the regular plotter pen.
-     *
-     * @return $this
      */
-    public function regularCut()
+    public function regularCut(): PlotBuilder
     {
         return $this->changePen(self::REGULAR_PEN);
     }
 
     /**
      * Changes the pen pressure in gram.
-     *
-     * @param int $gramPressure
-     * @return $this
      */
-    public function pressure(int $gramPressure)
+    public function pressure(int $gramPressure): PlotBuilder
     {
         return $this->pushCommand(sprintf('BP%d;', $gramPressure));
     }
@@ -159,11 +136,8 @@ class DmplBuilder implements PlotBuilder
      * 1 selects 0.001 inch
      * 5 selects 0.005 inch
      * M selects 0.1 mm
-     *
-     * @param $unit
-     * @return $this
      */
-    public function setMeasuringUnit($unit)
+    public function setMeasuringUnit($unit): PlotBuilder
     {
         if (! in_array($unit, self::MEASURING_UNITS)) {
             throw new \InvalidArgumentException(sprintf('[%s] is not a valid measuring unit.', $unit));
@@ -176,21 +150,16 @@ class DmplBuilder implements PlotBuilder
 
     /**
      * Changes the plotter velocity.
-     *
-     * @param int $velocity
-     * @return $this
      */
-    public function velocity(int $velocity)
+    public function velocity(int $velocity): PlotBuilder
     {
         return $this->pushCommand(sprintf('V%d;', $velocity));
     }
 
     /**
      * Flips the x, y coordinates.
-     *
-     * @return $this
      */
-    public function flipAxes()
+    public function flipAxes(): PlotBuilder
     {
         $this->flipAxes = true;
 
@@ -199,10 +168,8 @@ class DmplBuilder implements PlotBuilder
 
     /**
      * Cuts off paper when a operation finishes.
-     *
-     * @return $this
      */
-    public function cutOff()
+    public function cutOff(): PlotBuilder
     {
         $this->cutOff = true;
 

--- a/src/DmplBuilder.php
+++ b/src/DmplBuilder.php
@@ -8,6 +8,7 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
+
 namespace Nielsiano\DmplBuilder;
 
 /**
@@ -15,9 +16,8 @@ namespace Nielsiano\DmplBuilder;
  *
  * @package Nielsiano\DmplBuilder
  */
-class DmplBuilder
+class DmplBuilder implements PlotBuilder
 {
-
 
     /**
      * Generated DM/PL command instructions.

--- a/src/DmplBuilder.php
+++ b/src/DmplBuilder.php
@@ -82,6 +82,14 @@ class DmplBuilder implements PlotBuilder
     }
 
     /**
+     * Alias for `compile()` (for backwards compatibility).
+     */
+    public function compileDmpl(): string
+    {
+        return $this->compile();
+    }
+
+    /**
      * Pushes a command to the instructions.
      */
     public function pushCommand(string $command): PlotBuilder

--- a/src/PlotBuilder.php
+++ b/src/PlotBuilder.php
@@ -7,102 +7,69 @@ interface PlotBuilder
 {
     /**
      * Adds a new plot of x and y to machine instructions.
-     *
-     * @param int $x
-     * @param int $y
-     * @return $this
      */
-    public function plot(int $x, int $y);
+    public function plot(int $x, int $y): PlotBuilder;
 
     /**
      * Changes the pen of the plotter.
-     *
-     * @param int $pen
-     * @return $this
      */
-    public function changePen(int $pen);
+    public function changePen(int $pen): PlotBuilder;
 
     /**
      * Compiles a string in target format with machine instructions.
-     *
-     * @return string
      */
     public function compile(): string;
 
     /**
      * Pushes a command to the instructions.
-     *
-     * @param string $command
-     * @return $this
      */
-    public function pushCommand(string $command);
+    public function pushCommand(string $command): PlotBuilder;
 
     /**
      * Lifts the pen up.
-     *
-     * @return $this
      */
-    public function penUp();
+    public function penUp(): PlotBuilder;
 
     /**
      * Pushes the pen down on paper.
-     *
-     * @return $this
      */
-    public function penDown();
+    public function penDown(): PlotBuilder;
 
     /**
      * Changes the plotter pen to use flexcut.
-     *
-     * @return $this
      */
-    public function flexCut();
+    public function flexCut(): PlotBuilder;
 
     /**
      * Change to the regular plotter pen.
-     *
-     * @return $this
      */
-    public function regularCut();
+    public function regularCut(): PlotBuilder;
 
     /**
      * Changes the pen pressure in gram.
-     *
-     * @param int $gramPressure
-     * @return $this
      */
-    public function pressure(int $gramPressure);
+    public function pressure(int $gramPressure): PlotBuilder;
 
     /**
      * Specifies measuring unit.
      * 1 selects 0.001 inch
      * 5 selects 0.005 inch
      * M selects 0.1 mm
-     *
-     * @param $unit
-     * @return $this
      */
-    public function setMeasuringUnit($unit);
+    public function setMeasuringUnit($unit): PlotBuilder;
 
     /**
      * Changes the plotter velocity.
-     *
-     * @param int $velocity
-     * @return $this
      */
-    public function velocity(int $velocity);
+    public function velocity(int $velocity): PlotBuilder;
 
     /**
      * Flips the x, y coordinates.
-     *
-     * @return $this
      */
-    public function flipAxes();
+    public function flipAxes(): PlotBuilder;
 
     /**
      * Cuts off paper when a operation finishes.
-     *
-     * @return $this
      */
-    public function cutOff();
+    public function cutOff(): PlotBuilder;
 }

--- a/src/PlotBuilder.php
+++ b/src/PlotBuilder.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Nielsiano\DmplBuilder;
+
+
+interface PlotBuilder
+{
+    /**
+     * Adds a new plot of x and y to machine instructions.
+     *
+     * @param int $x
+     * @param int $y
+     * @return $this
+     */
+    public function plot(int $x, int $y);
+
+    /**
+     * Changes the pen of the plotter.
+     *
+     * @param int $pen
+     * @return $this
+     */
+    public function changePen(int $pen);
+
+    /**
+     * Compiles a string in DMPL format with machine instructions.
+     *
+     * @return string
+     */
+    public function compileDmpl(): string;
+
+    /**
+     * Pushes a command to the instructions.
+     *
+     * @param string $command
+     * @return $this
+     */
+    public function pushCommand(string $command);
+
+    /**
+     * Lifts the pen up.
+     *
+     * @return $this
+     */
+    public function penUp();
+
+    /**
+     * Pushes the pen down on paper.
+     *
+     * @return $this
+     */
+    public function penDown();
+
+    /**
+     * Changes the plotter pen to use flexcut.
+     *
+     * @return $this
+     */
+    public function flexCut();
+
+    /**
+     * Change to the regular plotter pen.
+     *
+     * @return $this
+     */
+    public function regularCut();
+
+    /**
+     * Changes the pen pressure in gram.
+     *
+     * @param int $gramPressure
+     * @return $this
+     */
+    public function pressure(int $gramPressure);
+
+    /**
+     * Specifies measuring unit.
+     * 1 selects 0.001 inch
+     * 5 selects 0.005 inch
+     * M selects 0.1 mm
+     *
+     * @param $unit
+     * @return $this
+     */
+    public function setMeasuringUnit($unit);
+
+    /**
+     * Changes the plotter velocity.
+     *
+     * @param int $velocity
+     * @return $this
+     */
+    public function velocity(int $velocity);
+
+    /**
+     * Flips the x, y coordinates.
+     *
+     * @return $this
+     */
+    public function flipAxes();
+
+    /**
+     * Cuts off paper when a operation finishes.
+     *
+     * @return $this
+     */
+    public function cutOff();
+}

--- a/src/PlotBuilder.php
+++ b/src/PlotBuilder.php
@@ -23,11 +23,11 @@ interface PlotBuilder
     public function changePen(int $pen);
 
     /**
-     * Compiles a string in DMPL format with machine instructions.
+     * Compiles a string in target format with machine instructions.
      *
      * @return string
      */
-    public function compileDmpl(): string;
+    public function compile(): string;
 
     /**
      * Pushes a command to the instructions.

--- a/src/SvgBuilder.php
+++ b/src/SvgBuilder.php
@@ -80,18 +80,18 @@ class SvgBuilder implements PlotBuilder
         $height = ($this->maxY * $this->scale) . $this->unit;
 
         return <<<SVG
-<svg xmlns="http://www.w3.org/2000/svg" width="{$width}" height="{$height}">
+<svg xmlns="http://www.w3.org/2000/svg" width="{$width}" height="{$height}" viewBox="0 0 {$this->maxX} {$this->maxY}">
     <defs>
         <style>
             line.regular {
-                stroke: rgb(255,0,0);
-                stroke-width: 2;
+                stroke: rgb(0,0,255);
+                stroke-width: 4;
             }
 
             line.flex {
                 stroke: rgb(255,0,0);
-                stroke-width: 2;
-                stroke-dasharray: 10 2;
+                stroke-width: 4;
+                stroke-dasharray: 20 4;
             }
         </style>
     </defs>
@@ -220,4 +220,5 @@ SVG;
 
         return $this;
     }
+
 }

--- a/src/SvgBuilder.php
+++ b/src/SvgBuilder.php
@@ -2,6 +2,8 @@
 
 namespace Nielsiano\DmplBuilder;
 
+use Exception;
+
 /**
  * Illustrate a plot program visually as an SVG line drawing.
  */
@@ -24,6 +26,8 @@ class SvgBuilder implements PlotBuilder
     protected $axesFlipped = false;
     protected $penIsDown = true;
     protected $tool = 'regular';
+    protected $unit = 'mm';
+    protected $scale = 0.1;
 
     /**
      * Adds a new plot of x and y to machine instructions.
@@ -72,8 +76,11 @@ class SvgBuilder implements PlotBuilder
     {
         $instructions = implode("\n", $this->instructions);
 
+        $width = ($this->maxX * $this->scale) . $this->unit;
+        $height = ($this->maxY * $this->scale) . $this->unit;
+
         return <<<SVG
-<svg xmlns="http://www.w3.org/2000/svg" width="{$this->maxX}" height="{$this->maxY}">
+<svg xmlns="http://www.w3.org/2000/svg" width="{$width}" height="{$height}">
     <defs>
         <style>
             line.regular {
@@ -157,7 +164,24 @@ SVG;
      */
     public function setMeasuringUnit($unit): PlotBuilder
     {
-        // TODO: Implement setMeasuringUnit() method.
+        switch ($unit) {
+            case 'M':
+                $this->unit = 'mm';
+                $this->scale = 0.1;
+                break;
+            case 1:
+                $this->unit = 'in';
+                $this->scale = 0.001;
+                break;
+            case 5:
+                $this->unit = 'in';
+                $this->scale = 0.005;
+                break;
+            default:
+                throw new Exception('Unhandled unit: ' . $unit);
+        }
+
+        return $this;
     }
 
     /**

--- a/src/SvgBuilder.php
+++ b/src/SvgBuilder.php
@@ -1,0 +1,190 @@
+<?php
+
+namespace Nielsiano\DmplBuilder;
+
+/**
+ * Illustrate a plot program visually as an SVG line drawing.
+ */
+class SvgBuilder implements PlotBuilder
+{
+    /**
+     * Current position.
+     */
+    protected $x = 0;
+    protected $y = 0;
+
+    protected $instructions = [];
+
+    protected $axesFlipped = false;
+    protected $penIsDown = true;
+    protected $tool = 'regular';
+
+    /**
+     * Adds a new plot of x and y to machine instructions.
+     */
+    public function plot(int $x, int $y): PlotBuilder
+    {
+
+        if ($this->axesFlipped) {
+            list($x, $y) = [$y, $x];
+        }
+
+        $targetX = $this->x + $x;
+        $targetY = $this->y + $y;
+
+        if ($this->penIsDown) {
+            $this->pushInstruction('line', [
+                'x1'    => $this->x,
+                'y1'    => $this->y,
+                'x2'    => $targetX,
+                'y2'    => $targetY,
+                'class' => $this->tool
+            ]);
+        }
+
+        $this->x = $targetX;
+        $this->y = $targetY;
+
+        return $this;
+    }
+
+    /**
+     * Changes the pen of the plotter.
+     */
+    public function changePen(int $pen): PlotBuilder
+    {
+        // TODO: Implement changePen() method.
+    }
+
+    /**
+     * Compiles a string in target format with machine instructions.
+     */
+    public function compile(): string
+    {
+        $instructions = implode("\n", $this->instructions);
+
+        return <<<SVG
+<svg xmlns="http://www.w3.org/2000/svg">
+    <defs>
+        <style>
+            line.regular {
+                stroke: rgb(255,0,0);
+                stroke-width: 2;
+            }
+
+            line.flex {
+                stroke: rgb(255,0,0);
+                stroke-width: 2;
+                stroke-dasharray: 10 2;
+            }
+        </style>
+    </defs>
+    {$instructions}
+</svg>
+SVG;
+    }
+
+    /**
+     * Pushes a command to the instructions.
+     */
+    public function pushCommand(string $command): PlotBuilder
+    {
+        // TODO: Implement pushCommand() method.
+    }
+
+    /**
+     * Lifts the pen up.
+     */
+    public function penUp(): PlotBuilder
+    {
+        $this->penIsDown = false;
+
+        return $this;
+    }
+
+    /**
+     * Pushes the pen down on paper.
+     */
+    public function penDown(): PlotBuilder
+    {
+        $this->penIsDown = true;
+
+        return $this;
+    }
+
+    /**
+     * Changes the plotter pen to use flexcut.
+     */
+    public function flexCut(): PlotBuilder
+    {
+        $this->tool = 'flex';
+
+        return $this;
+    }
+
+    /**
+     * Change to the regular plotter pen.
+     */
+    public function regularCut(): PlotBuilder
+    {
+        $this->tool = 'regular';
+
+        return $this;
+    }
+
+    /**
+     * Changes the pen pressure in gram.
+     */
+    public function pressure(int $gramPressure): PlotBuilder
+    {
+        // TODO: Simulate pressure with stroke width, perhaps?
+    }
+
+    /**
+     * Specifies measuring unit.
+     * 1 selects 0.001 inch
+     * 5 selects 0.005 inch
+     * M selects 0.1 mm
+     */
+    public function setMeasuringUnit($unit): PlotBuilder
+    {
+        // TODO: Implement setMeasuringUnit() method.
+    }
+
+    /**
+     * Changes the plotter velocity.
+     */
+    public function velocity(int $velocity): PlotBuilder
+    {
+        // TODO: Implement velocity() method.
+    }
+
+    /**
+     * Flips the x, y coordinates.
+     */
+    public function flipAxes(): PlotBuilder
+    {
+        $this->axesFlipped = true;
+
+        return $this;
+    }
+
+    /**
+     * Cuts off paper when a operation finishes.
+     */
+    public function cutOff(): PlotBuilder
+    {
+        // TODO: Implement cutOff() method.
+    }
+
+    protected function pushInstruction(string $name, array $parameters): PlotBuilder
+    {
+        $instruction = '<' . $name;
+        foreach ($parameters as $parameter => $value) {
+            $instruction .= ' ' . $parameter . '="' . htmlspecialchars($value) . '"';
+        }
+        $this->instructions[] = $instruction . ' />';
+
+        return $this;
+    }
+}

--- a/src/SvgBuilder.php
+++ b/src/SvgBuilder.php
@@ -13,6 +13,12 @@ class SvgBuilder implements PlotBuilder
     protected $x = 0;
     protected $y = 0;
 
+    /**
+     * Extent of drawing
+     */
+    protected $maxX = 0;
+    protected $maxY = 0;
+
     protected $instructions = [];
 
     protected $axesFlipped = false;
@@ -31,6 +37,9 @@ class SvgBuilder implements PlotBuilder
 
         $targetX = $this->x + $x;
         $targetY = $this->y + $y;
+
+        $this->maxX = max($this->maxX, $targetX);
+        $this->maxY = max($this->maxY, $targetY);
 
         if ($this->penIsDown) {
             $this->pushInstruction('line', [
@@ -64,7 +73,7 @@ class SvgBuilder implements PlotBuilder
         $instructions = implode("\n", $this->instructions);
 
         return <<<SVG
-<svg xmlns="http://www.w3.org/2000/svg">
+<svg xmlns="http://www.w3.org/2000/svg" width="{$this->maxX}" height="{$this->maxY}">
     <defs>
         <style>
             line.regular {

--- a/tests/DmplBuilderTest.php
+++ b/tests/DmplBuilderTest.php
@@ -19,83 +19,83 @@ class DmplBuilderTest extends \PHPUnit_Framework_TestCase
 
     public function test_it_can_init_and_return_start_instructions()
     {
-        $this->assertEquals(';: ECM,U H L0,A100,100,R,e', $this->builder->compileDmpl());
+        $this->assertEquals(';: ECM,U H L0,A100,100,R,e', $this->builder->compile());
     }
 
     public function test_it_can_add_pen_up_to_dmpl_string()
     {
         $this->builder->penUp();
-        $this->assertEquals(';: ECM,U H L0,A100,100,R,U,e', $this->builder->compileDmpl());
+        $this->assertEquals(';: ECM,U H L0,A100,100,R,U,e', $this->builder->compile());
     }
 
     public function test_it_can_add_pen_down_to_dmpl_string()
     {
         $this->builder->penDown();
-        $this->assertEquals(';: ECM,U H L0,A100,100,R,D,e', $this->builder->compileDmpl());
+        $this->assertEquals(';: ECM,U H L0,A100,100,R,D,e', $this->builder->compile());
     }
 
     public function test_it_can_change_pen_tool_to_regular_cut()
     {
         $this->builder->regularCut();
-        $this->assertEquals(';: ECM,U H L0,A100,100,R,P0;,e', $this->builder->compileDmpl());
+        $this->assertEquals(';: ECM,U H L0,A100,100,R,P0;,e', $this->builder->compile());
     }
 
     public function test_it_can_change_pen_tool_to_flex_cut()
     {
         $this->builder->flexCut();
-        $this->assertEquals(';: ECM,U H L0,A100,100,R,P6;,e', $this->builder->compileDmpl());
+        $this->assertEquals(';: ECM,U H L0,A100,100,R,P6;,e', $this->builder->compile());
     }
 
     public function test_it_can_change_pressure_in_gram()
     {
         $this->builder->pressure(80);
-        $this->assertEquals(';: ECM,U H L0,A100,100,R,BP80;,e', $this->builder->compileDmpl());
+        $this->assertEquals(';: ECM,U H L0,A100,100,R,BP80;,e', $this->builder->compile());
     }
 
     public function test_it_can_change_velocity()
     {
         $this->builder->velocity(100);
-        $this->assertEquals(';: ECM,U H L0,A100,100,R,V100;,e', $this->builder->compileDmpl());
+        $this->assertEquals(';: ECM,U H L0,A100,100,R,V100;,e', $this->builder->compile());
     }
 
     public function test_it_can_finalize_the_dmpl_string_without_cutoff()
     {
-        $this->assertEquals(';: ECM,U H L0,A100,100,R,e', $this->builder->compileDmpl());
+        $this->assertEquals(';: ECM,U H L0,A100,100,R,e', $this->builder->compile());
     }
 
     public function test_it_can_add_a_new_plot()
     {
         $this->builder->plot(-1000, 5000);
-        $this->assertEquals(';: ECM,U H L0,A100,100,R,-1000,5000,e', $this->builder->compileDmpl());
+        $this->assertEquals(';: ECM,U H L0,A100,100,R,-1000,5000,e', $this->builder->compile());
     }
 
     public function test_it_can_push_a_generic_command()
     {
         $this->builder->pushCommand('V10;');
-        $this->assertEquals(';: ECM,U H L0,A100,100,R,V10;,e', $this->builder->compileDmpl());
+        $this->assertEquals(';: ECM,U H L0,A100,100,R,V10;,e', $this->builder->compile());
     }
 
     public function test_it_can_chain_multiple_actions()
     {
         $this->builder->penUp()->regularCut()->penDown()->plot(-1984, 1337);
-        $this->assertEquals(';: ECM,U H L0,A100,100,R,U,P0;,D,-1984,1337,e', $this->builder->compileDmpl());
+        $this->assertEquals(';: ECM,U H L0,A100,100,R,U,P0;,D,-1984,1337,e', $this->builder->compile());
     }
 
     public function test_it_can_flip_axes()
     {
         $this->builder->flipAxes()->plot(-1, 2)->plot(1337, 1984);
-        $this->assertEquals(';: ECM,U H L0,A100,100,R,2,-1,1984,1337,e', $this->builder->compileDmpl());
+        $this->assertEquals(';: ECM,U H L0,A100,100,R,2,-1,1984,1337,e', $this->builder->compile());
     }
 
     public function test_it_can_finalize_the_dmpl_string_with_cutoff()
     {
-        $this->assertEquals(';: ECM,U H L0,A100,100,R,;:c,e', $this->builder->cutOff()->compileDmpl());
+        $this->assertEquals(';: ECM,U H L0,A100,100,R,;:c,e', $this->builder->cutOff()->compile());
     }
 
     public function test_it_can_change_pen()
     {
         $this->builder->changePen(3);
-        $this->assertEquals(';: ECM,U H L0,A100,100,R,P3;,e', $this->builder->compileDmpl());
+        $this->assertEquals(';: ECM,U H L0,A100,100,R,P3;,e', $this->builder->compile());
     }
     
     public function test_it_will_throw_exception_when_invalid_pen_is_chosen()
@@ -107,7 +107,7 @@ class DmplBuilderTest extends \PHPUnit_Framework_TestCase
     public function test_it_can_change_measuring_unit()
     {
         $this->builder->setMeasuringUnit('M');
-        $this->assertEquals(';: ECM,U H L0,A100,100,R,e', $this->builder->compileDmpl());
+        $this->assertEquals(';: ECM,U H L0,A100,100,R,e', $this->builder->compile());
     }
 
     public function test_it_will_throw_exception_when_invalid_measuring_unit_is_chosen()

--- a/tests/SvgBuilderTest.php
+++ b/tests/SvgBuilderTest.php
@@ -54,4 +54,19 @@ class SvgBuilderTest extends \PHPUnit_Framework_TestCase
             $this->builder->compile());
     }
 
+    public function test_it_can_determine_extent_of_drawing()
+    {
+        $this->builder
+            ->plot(100, 200);
+
+        $this->assertContains('<svg xmlns="http://www.w3.org/2000/svg" width="100" height="200"',
+            $this->builder->compile());
+
+        $this->builder
+            ->plot(50, 50);
+
+        $this->assertContains('<svg xmlns="http://www.w3.org/2000/svg" width="150" height="250"',
+            $this->builder->compile());
+    }
+
 }

--- a/tests/SvgBuilderTest.php
+++ b/tests/SvgBuilderTest.php
@@ -57,15 +57,16 @@ class SvgBuilderTest extends \PHPUnit_Framework_TestCase
     public function test_it_can_determine_extent_of_drawing()
     {
         $this->builder
+            ->setMeasuringUnit('M')
             ->plot(100, 200);
 
-        $this->assertContains('<svg xmlns="http://www.w3.org/2000/svg" width="100" height="200"',
+        $this->assertContains('<svg xmlns="http://www.w3.org/2000/svg" width="10mm" height="20mm"',
             $this->builder->compile());
 
         $this->builder
             ->plot(50, 50);
 
-        $this->assertContains('<svg xmlns="http://www.w3.org/2000/svg" width="150" height="250"',
+        $this->assertContains('<svg xmlns="http://www.w3.org/2000/svg" width="15mm" height="25mm"',
             $this->builder->compile());
     }
 

--- a/tests/SvgBuilderTest.php
+++ b/tests/SvgBuilderTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Nielsiano\DmplBuilder\Tests;
+
+use Nielsiano\DmplBuilder\SvgBuilder;
+
+class SvgBuilderTest extends \PHPUnit_Framework_TestCase
+{
+
+    /**
+     * @var SvgBuilder
+     */
+    protected $builder;
+
+    public function setUp()
+    {
+        $this->builder = new SvgBuilder();
+    }
+
+    public function test_it_can_draw_a_line()
+    {
+        $this->builder
+            ->plot(100, 200);
+
+        $this->assertContains('<line x1="0" y1="0" x2="100" y2="200" class="regular" />',
+            $this->builder->compile());
+    }
+
+    public function test_it_can_flip_axes()
+    {
+        $this->builder
+            ->flipAxes()
+            ->plot(100, 200);
+
+        $this->assertContains('<line x1="0" y1="0" x2="200" y2="100" class="regular" />',
+            $this->builder->compile());
+    }
+
+    public function test_it_will_not_output_plots_while_pen_is_up()
+    {
+        $this->builder
+            ->penUp()
+            ->plot(100, 200);
+        $this->assertNotContains('<line ', $this->builder->compile());
+    }
+
+    public function test_it_can_select_flex_cut()
+    {
+        $this->builder
+            ->flexCut()
+            ->plot(100, 200);
+
+        $this->assertContains('<line x1="0" y1="0" x2="100" y2="200" class="flex" />',
+            $this->builder->compile());
+    }
+
+}


### PR DESCRIPTION
This pull request
- defines a generic `PlotBuilder` interface (which is somewhat agnostic of the output format) and
- adds an SVG driver which outputs a preview of the plot which is easy to inspect visually.

<img width="1048" alt="screen shot 2017-10-31 at 15 04 38" src="https://user-images.githubusercontent.com/20393/32213307-442b20e4-be4d-11e7-8916-46fef9e6a084.png">
